### PR TITLE
TestSessionLabelProviderCustom shows JUnit 5 TestTemplate poorly

### DIFF
--- a/org.eclipse.jdt.junit.runners/src/org/eclipse/jdt/internal/junit/ui/TestSessionLabelProviderCustom.java
+++ b/org.eclipse.jdt.junit.runners/src/org/eclipse/jdt/internal/junit/ui/TestSessionLabelProviderCustom.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,8 @@ import java.text.NumberFormat;
 
 import org.eclipse.jdt.internal.junit.BasicElementLabels;
 import org.eclipse.jdt.internal.junit.Messages;
+import org.eclipse.jdt.internal.junit.model.TestCaseElement;
+import org.eclipse.jdt.internal.junit.model.TestSuiteElement;
 import org.eclipse.jdt.junit.model.ITestCaseElement;
 import org.eclipse.jdt.junit.model.ITestElement;
 import org.eclipse.jdt.junit.model.ITestRunSession;
@@ -111,10 +113,14 @@ public class TestSessionLabelProviderCustom extends LabelProvider implements ISt
 					return result;
 			}
 		}
-		if (element instanceof ITestCaseElement) {
-			return BasicElementLabels.getJavaElementName(((ITestCaseElement) element).getTestMethodName());
-		} else if (element instanceof ITestSuiteElement) {
-			return BasicElementLabels.getJavaElementName(((ITestSuiteElement) element).getSuiteTypeName());
+		if (element instanceof TestCaseElement) {
+			TestCaseElement testCaseElement= (TestCaseElement) element;
+			String displayName= testCaseElement.getDisplayName();
+			return BasicElementLabels.getJavaElementName(displayName != null ? displayName : testCaseElement.getTestMethodName());
+		} else if (element instanceof TestSuiteElement) {
+			TestSuiteElement testSuiteElement= (TestSuiteElement) element;
+			String displayName= testSuiteElement.getDisplayName();
+			return BasicElementLabels.getJavaElementName(displayName != null ? displayName : testSuiteElement.getSuiteTypeName());
 		}
 		return null;
 	}

--- a/org.eclipse.jdt.junit.runners/src/org/eclipse/jdt/junit/runners/Activator.java
+++ b/org.eclipse.jdt.junit.runners/src/org/eclipse/jdt/junit/runners/Activator.java
@@ -3,6 +3,7 @@ package org.eclipse.jdt.junit.runners;
 import java.util.ArrayList;
 
 import org.eclipse.jdt.internal.junit.launcher.ITestKind;
+import org.eclipse.jdt.internal.junit.launcher.TestKind;
 import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
@@ -47,7 +48,7 @@ public class Activator extends AbstractUIPlugin {
 			// https://bugs.eclipse.org/bugs/show_bug.cgi?id=443498
 			TestKindRegistry default1 = TestKindRegistry.getDefault();
 			@SuppressWarnings("unchecked")
-			ArrayList<ITestKind> kinds = default1.getAllKinds();
+			ArrayList<TestKind> kinds = default1.getAllKinds();
 			for (int i = 0; i < kinds.size(); i++) {
 				if (kinds.get(i).getId().equals(TestKindRegistry.JUNIT4_TEST_KIND_ID))
 					kinds.set(i, new PatchedTestKind(kinds.get(i)));

--- a/org.eclipse.jdt.junit.runners/src/org/eclipse/jdt/junit/runners/PatchSetup.java
+++ b/org.eclipse.jdt.junit.runners/src/org/eclipse/jdt/junit/runners/PatchSetup.java
@@ -212,9 +212,11 @@ public class PatchSetup implements IStartup {
 					String className = type.getFullyQualifiedName();
 					String id = testElement.getId();
 					String testName = ((ITestSuiteElement) testElement).getSuiteTypeName();
+					String displayName = testElement.getDisplayName();
+					String uniqueId = testElement.getUniqueId();
 					manager.add(new Separator());
-					manager.add(new RerunAction(RerunAction_label_run, fTestRunnerPart, id, className, testName, RUN_MODE));
-					manager.add(new RerunAction(RerunAction_label_debug, fTestRunnerPart, id, className, testName, DEBUG_MODE));
+					manager.add(new RerunAction(RerunAction_label_run, fTestRunnerPart, id, className, testName, displayName, uniqueId, RUN_MODE));
+					manager.add(new RerunAction(RerunAction_label_debug, fTestRunnerPart, id, className, testName, displayName, uniqueId, DEBUG_MODE));
 					manager.add(new Separator());
 				}
 			}


### PR DESCRIPTION
When org.eclipse.jdt.junit.runners is included in a product, JUnit 5 TestTemplate tests are not displayed correctly in the JUnit view. E.g. a RepeatTest is displayed as follows:

test.TestTemplatesJunit5
* test.TestTemplatesJunit5
** test1

Without this plug-in, the JUnit view has more useful contents:

TestTemplatesJunit5
* test1()
** repetition 1 of 1

This is due to outdated contents in TestSessionLabelProviderCustom, when compared to TestSessionLabelProvider. Only the latter was updated to deal with JUnit 5 tests.

This change adjusts TestSessionLabelProviderCustom.getSimpleLabel() to the change in TestSessionLabelProvider.getSimpleLabel() for: https://bugs.eclipse.org/bugs/show_bug.cgi?id=488566

Fixes: #18